### PR TITLE
Rocky 9 build fixes

### DIFF
--- a/release.mak
+++ b/release.mak
@@ -1,4 +1,17 @@
-PACKAGE_TOP=/afs/slac/g/lcls/package/
+########################
+### Package versions ###
+########################
+
+# Location of packages. On S3DF, this should be defaulted to EPICS_PACKAGE_TOP. On AFS, we default to an absolute AFS path
+# This may also be provided on the command line or in the environment
+ifeq ($(PACKAGE_TOP),)
+ifneq ($(EPICS_PACKAGE_TOP),)
+	PACKAGE_TOP     = $(EPICS_PACKAGE_TOP)
+else
+	$(error PACKAGE_TOP or EPICS_PACKAGE_TOP must be set in the environment or on the command line)
+endif
+endif
+
 CPSW_FRAMEWORK_VERSION=R4.4.1
 
 CPSW_DIR=$(PACKAGE_TOP)/cpsw/framework/$(CPSW_FRAMEWORK_VERSION)/src

--- a/src/AxiMicronN25Q.cc
+++ b/src/AxiMicronN25Q.cc
@@ -24,8 +24,6 @@
 #include "AxiMicronN25Q.h"
 #include <cpsw_entry_adapt.h>
 
-using namespace std;
-
 #define CMD_OFFSET 16
 
 #define READ_MASK   0x00000000 

--- a/src/PromApiImpl.cc
+++ b/src/PromApiImpl.cc
@@ -27,7 +27,10 @@
 
 #include "PromApiImpl.h"
 
-using namespace std;
+using std::hex;
+using std::dec;
+using std::cout;
+using std::endl;
 
 void CEEPromImpl::setFileReader(FileReader reader)
 {


### PR DESCRIPTION
* Improve `PACKAGE_TOP` handling 
* Remove `using namespace std;` and replace with more fine-grained `using` statements. This causes ambiguity with C++11 smart pointers and boost smart pointers.